### PR TITLE
:arrow_up: torch 1.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ botocore>=1.12.198,<1.30.0
 boto3>=1.9.198,<1.27.0
 
 gunicorn==20.1.0
-torch==1.12.0
+torch==1.13.1
 
 setuptools~=68.0.0
 scikit-learn~=1.2.1


### PR DESCRIPTION
torch 1.12.0 isn't available for python 3.11.