### PR TITLE
:arrow_up: scikit-learn 1.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ botocore>=1.12.198,<1.35.0
 gunicorn==22.0.0
 torch==2.4.0
 
-scikit-learn~=1.2.1
+scikit-learn~=1.3.2


### PR DESCRIPTION
@ndittren this seems to fix the tests here, which broke on the main branch, possibly due to my adding python 3.12 testing.